### PR TITLE
메인화면에 노출될 스코어링 조회 목록을 구현한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### QueryDSL ###
+src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,34 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.0'
+    implementation 'io.github.openfeign.querydsl:querydsl-apt:7.0'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:7.0:jakarta'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def generatedDir = "src/main/generated"
+
+sourceSets {
+    main {
+        java {
+            srcDir generatedDir
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory = file(generatedDir)
+}
+
+tasks.register('cleanGenerated', Delete) {
+    delete generatedDir
+}
+
+tasks.named('clean') {
+    dependsOn 'cleanGenerated'
 }

--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -85,4 +85,9 @@ public class MemeController {
     public ApiResponse<List<MemeSimpleResponse>> getMostCustomMemes() {
         return ApiResponse.success(memeAggregationLookUpService.getMostFrequentCustomMemes());
     }
+
+    @GetMapping("/rankings/top-rated")
+    public ApiResponse<List<MemeSimpleResponse>> getTopRatedMemes() {
+        return ApiResponse.success(memeAggregationLookUpService.getMostPopularMemes());
+    }
 }

--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import spring.memewikibe.api.controller.meme.response.CategoryResponse;
 import spring.memewikibe.api.controller.meme.response.MemeDetailResponse;
 import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+import spring.memewikibe.application.MemeAggregationLookUpService;
 import spring.memewikibe.application.MemeAggregationService;
 import spring.memewikibe.application.MemeLookUpService;
 import spring.memewikibe.support.response.ApiResponse;
@@ -19,10 +20,12 @@ public class MemeController {
 
     private final MemeAggregationService aggregationService;
     private final MemeLookUpService memeLookUpService;
+    private final MemeAggregationLookUpService memeAggregationLookUpService;
 
-    public MemeController(MemeAggregationService aggregationService, MemeLookUpService memeLookUpService) {
+    public MemeController(MemeAggregationService aggregationService, MemeLookUpService memeLookUpService, MemeAggregationLookUpService memeAggregationLookUpService) {
         this.aggregationService = aggregationService;
         this.memeLookUpService = memeLookUpService;
+        this.memeAggregationLookUpService = memeAggregationLookUpService;
     }
 
     @GetMapping
@@ -71,5 +74,10 @@ public class MemeController {
         @RequestParam(required = false, defaultValue = "20") int limit
     ) {
         return ApiResponse.success(memeLookUpService.getMemesByCategory(id, next, limit));
+    }
+
+    @GetMapping("/rankings/shared")
+    public ApiResponse<List<MemeSimpleResponse>> getMostSharedMemes() {
+        return ApiResponse.success(memeAggregationLookUpService.getMostFrequentSharedMemes());
     }
 }

--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -47,7 +47,7 @@ public class MemeController {
     }
 
     @ResponseStatus(HttpStatus.ACCEPTED)
-    @PostMapping("/{id}/own")
+    @PostMapping("/{id}/custom")
     public void makeOwnMeme(
         @PathVariable Long id
     ) {
@@ -79,5 +79,10 @@ public class MemeController {
     @GetMapping("/rankings/shared")
     public ApiResponse<List<MemeSimpleResponse>> getMostSharedMemes() {
         return ApiResponse.success(memeAggregationLookUpService.getMostFrequentSharedMemes());
+    }
+
+    @GetMapping("/rankings/custom")
+    public ApiResponse<List<MemeSimpleResponse>> getMostCustomMemes() {
+        return ApiResponse.success(memeAggregationLookUpService.getMostFrequentCustomMemes());
     }
 }

--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -29,13 +29,12 @@ public class MemeController {
     }
 
     @GetMapping
-    public ApiResponse<PageResponse<Cursor, MemeSimpleResponse>> getMemes(
+    public ApiResponse<PageResponse<Cursor, MemeDetailResponse>> getMemes(
         @RequestParam(required = false) Long next,
         @RequestParam(required = false) String query,
         @RequestParam(required = false, defaultValue = "20") int limit
     ) {
-        // TODO: 검색 및 전체조회
-        return null;
+        return ApiResponse.success(memeLookUpService.getMemesByQuery(query, next, limit));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -41,8 +41,7 @@ public class MemeController {
     public ApiResponse<MemeDetailResponse> getMeme(
         @PathVariable Long id
     ) {
-        // TODO: 상세 조회
-        return null;
+        return ApiResponse.success(memeLookUpService.getMemeById(id));
     }
 
     @ResponseStatus(HttpStatus.ACCEPTED)

--- a/src/main/java/spring/memewikibe/api/controller/meme/response/MemeSimpleResponse.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/response/MemeSimpleResponse.java
@@ -5,8 +5,7 @@ import java.util.Objects;
 public record MemeSimpleResponse(
     long id,
     String title,
-    String summary,
-    String image
+    String imgUrl
 ) {
     public MemeSimpleResponse {
         Objects.requireNonNull(title, "제목은 필수 입니다.");

--- a/src/main/java/spring/memewikibe/application/MemeAggregationLookUpService.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationLookUpService.java
@@ -1,0 +1,13 @@
+package spring.memewikibe.application;
+
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+
+import java.util.List;
+
+public interface MemeAggregationLookUpService {
+    List<MemeSimpleResponse> getMostFrequentSharedMemes();
+
+    List<MemeSimpleResponse> getMostFrequentCustomMemes();
+
+    List<MemeSimpleResponse> getMostPopularMemes();
+}

--- a/src/main/java/spring/memewikibe/application/MemeAggregationLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationLookUpServiceImpl.java
@@ -3,7 +3,9 @@ package spring.memewikibe.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+import spring.memewikibe.domain.meme.MemeAggregationResult;
 import spring.memewikibe.infrastructure.MemeCustomLogRepository;
+import spring.memewikibe.infrastructure.MemeRepository;
 import spring.memewikibe.infrastructure.MemeShareLogRepository;
 import spring.memewikibe.infrastructure.MemeViewLogRepository;
 
@@ -15,15 +17,18 @@ public class MemeAggregationLookUpServiceImpl implements MemeAggregationLookUpSe
 
     private final static Duration AGGREGATION_DURATION_PERIOD = Duration.ofDays(1);
     private final static int AGGREGATION_ITEM_COUNT = 10;
+    private final static int MOST_POPULAR_MEMES_COUNT = 6;
 
     private final MemeCustomLogRepository customLogRepository;
     private final MemeViewLogRepository viewLogRepository;
     private final MemeShareLogRepository shareLogRepository;
+    private final MemeRepository memeRepository;
 
-    public MemeAggregationLookUpServiceImpl(MemeCustomLogRepository customLogRepository, MemeViewLogRepository viewLogRepository, MemeShareLogRepository shareLogRepository) {
+    public MemeAggregationLookUpServiceImpl(MemeCustomLogRepository customLogRepository, MemeViewLogRepository viewLogRepository, MemeShareLogRepository shareLogRepository, MemeRepository memeRepository) {
         this.customLogRepository = customLogRepository;
         this.viewLogRepository = viewLogRepository;
         this.shareLogRepository = shareLogRepository;
+        this.memeRepository = memeRepository;
     }
 
 
@@ -39,8 +44,12 @@ public class MemeAggregationLookUpServiceImpl implements MemeAggregationLookUpSe
         return customLogRepository.findTopMemesByCustomCountWithin(AGGREGATION_DURATION_PERIOD, AGGREGATION_ITEM_COUNT);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<MemeSimpleResponse> getMostPopularMemes() {
-        return List.of();
+        List<MemeAggregationResult> aggregationResult = memeRepository.findTopRatedMemesBy(AGGREGATION_DURATION_PERIOD, MOST_POPULAR_MEMES_COUNT);
+        return aggregationResult.stream()
+            .map(it -> new MemeSimpleResponse(it.id(), it.title(), it.imgUrl()))
+            .toList();
     }
 }

--- a/src/main/java/spring/memewikibe/application/MemeAggregationLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationLookUpServiceImpl.java
@@ -1,0 +1,45 @@
+package spring.memewikibe.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+import spring.memewikibe.infrastructure.MemeCustomLogRepository;
+import spring.memewikibe.infrastructure.MemeShareLogRepository;
+import spring.memewikibe.infrastructure.MemeViewLogRepository;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+public class MemeAggregationLookUpServiceImpl implements MemeAggregationLookUpService {
+
+    private final static Duration AGGREGATION_DURATION_PERIOD = Duration.ofDays(1);
+    private final static int AGGREGATION_ITEM_COUNT = 10;
+
+    private final MemeCustomLogRepository customLogRepository;
+    private final MemeViewLogRepository viewLogRepository;
+    private final MemeShareLogRepository shareLogRepository;
+
+    public MemeAggregationLookUpServiceImpl(MemeCustomLogRepository customLogRepository, MemeViewLogRepository viewLogRepository, MemeShareLogRepository shareLogRepository) {
+        this.customLogRepository = customLogRepository;
+        this.viewLogRepository = viewLogRepository;
+        this.shareLogRepository = shareLogRepository;
+    }
+
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<MemeSimpleResponse> getMostFrequentSharedMemes() {
+        return shareLogRepository.findTopMemesByShareCountWithin(AGGREGATION_DURATION_PERIOD, AGGREGATION_ITEM_COUNT);
+    }
+
+    @Override
+    public List<MemeSimpleResponse> getMostFrequentCustomMemes() {
+        return List.of();
+    }
+
+    @Override
+    public List<MemeSimpleResponse> getMostPopularMemes() {
+        return List.of();
+    }
+}

--- a/src/main/java/spring/memewikibe/application/MemeAggregationLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationLookUpServiceImpl.java
@@ -33,9 +33,10 @@ public class MemeAggregationLookUpServiceImpl implements MemeAggregationLookUpSe
         return shareLogRepository.findTopMemesByShareCountWithin(AGGREGATION_DURATION_PERIOD, AGGREGATION_ITEM_COUNT);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<MemeSimpleResponse> getMostFrequentCustomMemes() {
-        return List.of();
+        return customLogRepository.findTopMemesByCustomCountWithin(AGGREGATION_DURATION_PERIOD, AGGREGATION_ITEM_COUNT);
     }
 
     @Override

--- a/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
@@ -1,10 +1,15 @@
 package spring.memewikibe.application;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 import spring.memewikibe.domain.meme.Meme;
 import spring.memewikibe.domain.meme.MemeCustomLog;
 import spring.memewikibe.domain.meme.MemeShareLog;
 import spring.memewikibe.domain.meme.MemeViewLog;
+import spring.memewikibe.domain.meme.event.MemeViewedEvent;
 import spring.memewikibe.infrastructure.MemeCustomLogRepository;
 import spring.memewikibe.infrastructure.MemeRepository;
 import spring.memewikibe.infrastructure.MemeShareLogRepository;
@@ -44,6 +49,13 @@ public class MemeAggregationServiceImpl implements MemeAggregationService {
     public void increaseShareMemeCount(Long memeId) {
         Meme meme = getMemeBy(memeId);
         memeShareLogRepository.save(MemeShareLog.of(meme));
+    }
+
+    @Async
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleMemeViewed(MemeViewedEvent event) {
+        increaseMemeViewCount(event.memeId());
     }
 
     private Meme getMemeBy(Long memeId) {

--- a/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
@@ -11,7 +11,7 @@ import spring.memewikibe.infrastructure.MemeShareLogRepository;
 import spring.memewikibe.infrastructure.MemeViewLogRepository;
 import spring.memewikibe.support.error.MemeWikiApplicationException;
 
-import static spring.memewikibe.support.error.ErrorType.MEME_NOT_FOUNT;
+import static spring.memewikibe.support.error.ErrorType.MEME_NOT_FOUND;
 
 @Service
 public class MemeAggregationServiceImpl implements MemeAggregationService {
@@ -47,6 +47,6 @@ public class MemeAggregationServiceImpl implements MemeAggregationService {
     }
 
     private Meme getMemeBy(Long memeId) {
-        return memeRepository.findById(memeId).orElseThrow(() -> new MemeWikiApplicationException(MEME_NOT_FOUNT));
+        return memeRepository.findById(memeId).orElseThrow(() -> new MemeWikiApplicationException(MEME_NOT_FOUND));
     }
 }

--- a/src/main/java/spring/memewikibe/application/MemeLookUpService.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpService.java
@@ -11,4 +11,6 @@ public interface MemeLookUpService {
     List<CategoryResponse> getAllCategories();
 
     PageResponse<Cursor, MemeDetailResponse> getMemesByCategory(Long id, Long next, int limit);
+
+    PageResponse<Cursor, MemeDetailResponse> getMemesByQuery(String query, Long next, int limit);
 }

--- a/src/main/java/spring/memewikibe/application/MemeLookUpService.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpService.java
@@ -13,4 +13,6 @@ public interface MemeLookUpService {
     PageResponse<Cursor, MemeDetailResponse> getMemesByCategory(Long id, Long next, int limit);
 
     PageResponse<Cursor, MemeDetailResponse> getMemesByQuery(String query, Long next, int limit);
+
+    MemeDetailResponse getMemeById(Long id);
 }

--- a/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
@@ -60,6 +60,14 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
         return createPageResponseBy(foundMemes, limit);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public MemeDetailResponse getMemeById(Long id) {
+        Meme meme = memeRepository.findById(id)
+            .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUND));
+        return new MemeDetailResponse(meme.getId(), meme.getTitle(), meme.getUsageContext(), meme.getOrigin(), meme.getTrendPeriod(), meme.getImgUrl(), meme.getHashtags());
+    }
+
     private PageResponse<Cursor, MemeDetailResponse> createPageResponseBy(List<Meme> memes, int limit) {
         Cursor cursor = Cursor.of(memes, limit);
         List<MemeDetailResponse> response = memes.stream()
@@ -83,7 +91,7 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
         }
 
         Meme meme = memeRepository.findById(next)
-            .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUNT));
+            .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUND));
         return memeCategoryRepository.findByCategoryAndMemeGreaterThanOrderByMemeAsc(category, meme, Limit.of(limit + 1))
             .stream()
             .map(MemeCategory::getMeme)

--- a/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
@@ -1,5 +1,6 @@
 package spring.memewikibe.application;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +9,7 @@ import spring.memewikibe.api.controller.meme.response.MemeDetailResponse;
 import spring.memewikibe.domain.meme.Category;
 import spring.memewikibe.domain.meme.Meme;
 import spring.memewikibe.domain.meme.MemeCategory;
+import spring.memewikibe.domain.meme.event.MemeViewedEvent;
 import spring.memewikibe.infrastructure.CategoryRepository;
 import spring.memewikibe.infrastructure.MemeCategoryRepository;
 import spring.memewikibe.infrastructure.MemeRepository;
@@ -24,11 +26,13 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
     private final CategoryRepository categoryRepository;
     private final MemeRepository memeRepository;
     private final MemeCategoryRepository memeCategoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public MemeLookUpServiceImpl(CategoryRepository categoryRepository, MemeRepository memeRepository, MemeCategoryRepository memeCategoryRepository) {
+    public MemeLookUpServiceImpl(CategoryRepository categoryRepository, MemeRepository memeRepository, MemeCategoryRepository memeCategoryRepository, ApplicationEventPublisher eventPublisher) {
         this.categoryRepository = categoryRepository;
         this.memeRepository = memeRepository;
         this.memeCategoryRepository = memeCategoryRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -65,6 +69,9 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
     public MemeDetailResponse getMemeById(Long id) {
         Meme meme = memeRepository.findById(id)
             .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUND));
+
+        eventPublisher.publishEvent(new MemeViewedEvent(id));
+
         return new MemeDetailResponse(meme.getId(), meme.getTitle(), meme.getUsageContext(), meme.getOrigin(), meme.getTrendPeriod(), meme.getImgUrl(), meme.getHashtags());
     }
 

--- a/src/main/java/spring/memewikibe/config/AsyncConfig.java
+++ b/src/main/java/spring/memewikibe/config/AsyncConfig.java
@@ -1,0 +1,74 @@
+package spring.memewikibe.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
+    public ThreadPoolTaskExecutor asyncTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        int cpuCores = Runtime.getRuntime().availableProcessors();
+        executor.setCorePoolSize(cpuCores);
+        executor.setMaxPoolSize(cpuCores);
+        executor.setThreadNamePrefix("async");
+        executor.setQueueCapacity(1_000);
+        executor.setAwaitTerminationSeconds(5);
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setTaskDecorator(new MdcTaskDecorator());
+        executor.initialize();
+        executor.getThreadPoolExecutor().prestartAllCoreThreads();
+        return executor;
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return asyncTaskExecutor();
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
+
+    @Slf4j
+    private static class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+        @Override
+        public void handleUncaughtException(Throwable throwable, Method method, Object... objects) {
+            log.error("Error on async execution: ", throwable);
+        }
+    }
+
+    private static class MdcTaskDecorator implements TaskDecorator {
+
+        @Override
+        public Runnable decorate(Runnable runnable) {
+            Map<String, String> contextMap = MDC.getCopyOfContextMap();
+            return () -> {
+                try {
+                    if (contextMap != null) {
+                        MDC.setContextMap(contextMap);
+                    }
+                    runnable.run();
+                } finally {
+                    MDC.clear();
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/spring/memewikibe/domain/meme/MemeAggregationResult.java
+++ b/src/main/java/spring/memewikibe/domain/meme/MemeAggregationResult.java
@@ -1,0 +1,13 @@
+package spring.memewikibe.domain.meme;
+
+public record MemeAggregationResult(
+    long id,
+    String title,
+    String imgUrl,
+    long viewCount,
+    long sharedCount,
+    long customCount,
+    long totalScore
+) {
+
+}

--- a/src/main/java/spring/memewikibe/domain/meme/event/MemeViewedEvent.java
+++ b/src/main/java/spring/memewikibe/domain/meme/event/MemeViewedEvent.java
@@ -1,0 +1,4 @@
+package spring.memewikibe.domain.meme.event;
+
+public record MemeViewedEvent(Long memeId) {
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeAggregationRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeAggregationRepository.java
@@ -1,0 +1,10 @@
+package spring.memewikibe.infrastructure;
+
+import spring.memewikibe.domain.meme.MemeAggregationResult;
+
+import java.time.Duration;
+import java.util.List;
+
+public interface MemeAggregationRepository {
+    List<MemeAggregationResult> findTopRatedMemesBy(Duration duration, int limit);
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeAggregationRepositoryImpl.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeAggregationRepositoryImpl.java
@@ -1,0 +1,80 @@
+package spring.memewikibe.infrastructure;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLSubQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+import spring.memewikibe.domain.meme.MemeAggregationResult;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static spring.memewikibe.domain.meme.QMeme.meme;
+import static spring.memewikibe.domain.meme.QMemeCustomLog.memeCustomLog;
+import static spring.memewikibe.domain.meme.QMemeShareLog.memeShareLog;
+import static spring.memewikibe.domain.meme.QMemeViewLog.memeViewLog;
+
+@Repository
+public class MemeAggregationRepositoryImpl implements MemeAggregationRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemeAggregationRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<MemeAggregationResult> findTopRatedMemesBy(Duration duration, int limit) {
+        LocalDateTime aggregationPoint = LocalDateTime.now().minus(duration);
+
+        final int CUSTOM_WEIGHT = 3;
+        final int SHARE_WEIGHT = 2;
+        final int VIEW_WEIGHT = 1;
+
+        JPQLSubQuery<Long> customCount = JPAExpressions
+            .select(memeCustomLog.count())
+            .from(memeCustomLog)
+            .where(memeCustomLog.meme.eq(meme)
+                .and(memeCustomLog.createdAt.gt(aggregationPoint)));
+
+        JPQLSubQuery<Long> shareCount = JPAExpressions
+            .select(memeShareLog.count())
+            .from(memeShareLog)
+            .where(memeShareLog.meme.eq(meme)
+                .and(memeShareLog.createdAt.gt(aggregationPoint)));
+
+        JPQLSubQuery<Long> viewCount = JPAExpressions
+            .select(memeViewLog.count())
+            .from(memeViewLog)
+            .where(memeViewLog.meme.eq(meme)
+                .and(memeViewLog.createdAt.gt(aggregationPoint)));
+
+        NumberTemplate<Long> customCountExpression = Expressions.numberTemplate(Long.class, "COALESCE(({0}), 0)", customCount);
+        NumberTemplate<Long> shareCountExpression = Expressions.numberTemplate(Long.class, "COALESCE(({0}), 0)", shareCount);
+        NumberTemplate<Long> viewCountExpression = Expressions.numberTemplate(Long.class, "COALESCE(({0}), 0)", viewCount);
+
+        return queryFactory
+            .select(Projections.constructor(MemeAggregationResult.class,
+                meme.id,
+                meme.title,
+                meme.imgUrl,
+                viewCountExpression,
+                shareCountExpression,
+                customCountExpression,
+                customCountExpression.multiply(CUSTOM_WEIGHT)
+                    .add(shareCountExpression.multiply(SHARE_WEIGHT))
+                    .add(viewCountExpression.multiply(VIEW_WEIGHT))
+            ))
+            .from(meme)
+            .orderBy(customCountExpression.multiply(CUSTOM_WEIGHT)
+                    .add(shareCountExpression.multiply(SHARE_WEIGHT))
+                    .add(viewCountExpression.multiply(VIEW_WEIGHT)).desc(),
+                meme.id.desc())
+            .limit(limit)
+            .fetch();
+    }
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeCustomLogCustomRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeCustomLogCustomRepository.java
@@ -1,0 +1,10 @@
+package spring.memewikibe.infrastructure;
+
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+
+import java.time.Duration;
+import java.util.List;
+
+public interface MemeCustomLogCustomRepository {
+    List<MemeSimpleResponse> findTopMemesByCustomCountWithin(Duration duration, int limit);
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeCustomLogCustomRepositoryImpl.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeCustomLogCustomRepositoryImpl.java
@@ -1,0 +1,42 @@
+package spring.memewikibe.infrastructure;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static spring.memewikibe.domain.meme.QMeme.meme;
+import static spring.memewikibe.domain.meme.QMemeCustomLog.memeCustomLog;
+
+@Repository
+public class MemeCustomLogCustomRepositoryImpl implements MemeCustomLogCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemeCustomLogCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<MemeSimpleResponse> findTopMemesByCustomCountWithin(Duration duration, int limit) {
+        LocalDateTime aggregationPoint = LocalDateTime.now().minus(duration);
+
+        return queryFactory
+            .select(Projections.constructor(MemeSimpleResponse.class,
+                meme.id,
+                meme.title,
+                meme.imgUrl
+            ))
+            .from(memeCustomLog)
+            .join(memeCustomLog.meme, meme)
+            .where(memeCustomLog.createdAt.gt(aggregationPoint))
+            .groupBy(meme.id, meme.title, meme.imgUrl)
+            .orderBy(memeCustomLog.count().desc(), meme.id.desc())
+            .limit(limit)
+            .fetch();
+    }
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeCustomLogRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeCustomLogRepository.java
@@ -3,5 +3,5 @@ package spring.memewikibe.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.memewikibe.domain.meme.MemeCustomLog;
 
-public interface MemeCustomLogRepository extends JpaRepository<MemeCustomLog, Long> {
+public interface MemeCustomLogRepository extends JpaRepository<MemeCustomLog, Long>, MemeCustomLogCustomRepository {
 }

--- a/src/main/java/spring/memewikibe/infrastructure/MemeRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeRepository.java
@@ -3,5 +3,5 @@ package spring.memewikibe.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.memewikibe.domain.meme.Meme;
 
-public interface MemeRepository extends JpaRepository<Meme, Long> {
+public interface MemeRepository extends JpaRepository<Meme, Long>, MemeAggregationRepository {
 }

--- a/src/main/java/spring/memewikibe/infrastructure/MemeRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeRepository.java
@@ -1,7 +1,13 @@
 package spring.memewikibe.infrastructure;
 
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.memewikibe.domain.meme.Meme;
 
+import java.util.List;
+
 public interface MemeRepository extends JpaRepository<Meme, Long>, MemeAggregationRepository {
+    List<Meme> findByTitleContainingOrderByIdDesc(String title, Limit limit);
+
+    List<Meme> findByTitleContainingAndIdLessThanOrderByIdDesc(String title, Long id, Limit limit);
 }

--- a/src/main/java/spring/memewikibe/infrastructure/MemeShareLogCustomRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeShareLogCustomRepository.java
@@ -1,0 +1,10 @@
+package spring.memewikibe.infrastructure;
+
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+
+import java.time.Duration;
+import java.util.List;
+
+public interface MemeShareLogCustomRepository {
+    List<MemeSimpleResponse> findTopMemesByShareCountWithin(Duration duration, int limit);
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeShareLogCustomRepositoryImpl.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeShareLogCustomRepositoryImpl.java
@@ -1,0 +1,42 @@
+package spring.memewikibe.infrastructure;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static spring.memewikibe.domain.meme.QMeme.meme;
+import static spring.memewikibe.domain.meme.QMemeShareLog.memeShareLog;
+
+@Repository
+public class MemeShareLogCustomRepositoryImpl implements MemeShareLogCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MemeShareLogCustomRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<MemeSimpleResponse> findTopMemesByShareCountWithin(Duration duration, int limit) {
+        LocalDateTime aggregationPoint = LocalDateTime.now().minus(duration);
+
+        return queryFactory
+            .select(Projections.constructor(MemeSimpleResponse.class,
+                meme.id,
+                meme.title,
+                meme.imgUrl
+            ))
+            .from(memeShareLog)
+            .join(memeShareLog.meme, meme)
+            .where(memeShareLog.createdAt.gt(aggregationPoint))
+            .groupBy(meme.id, meme.title, meme.imgUrl)
+            .orderBy(memeShareLog.count().desc(), meme.id.desc())
+            .limit(limit)
+            .fetch();
+    }
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeShareLogRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeShareLogRepository.java
@@ -3,5 +3,5 @@ package spring.memewikibe.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.memewikibe.domain.meme.MemeShareLog;
 
-public interface MemeShareLogRepository extends JpaRepository<MemeShareLog, Long> {
+public interface MemeShareLogRepository extends JpaRepository<MemeShareLog, Long>, MemeShareLogCustomRepository {
 }

--- a/src/main/java/spring/memewikibe/infrastructure/QueryDslConfig.java
+++ b/src/main/java/spring/memewikibe/infrastructure/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package spring.memewikibe.infrastructure;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/spring/memewikibe/support/error/ErrorType.java
+++ b/src/main/java/spring/memewikibe/support/error/ErrorType.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
     DEFAULT_ERROR(
         HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "예기치 못한 에러가 발생했습니다.", LogLevel.ERROR),
-    MEME_NOT_FOUNT(
+    MEME_NOT_FOUND(
         HttpStatus.NOT_FOUND, ErrorCode.E404, "존재하지 않는 밈입니다.", LogLevel.WARN),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "존재하지 않는 카테고리입니다.", LogLevel.WARN);
 

--- a/src/main/java/spring/memewikibe/support/error/MemeWikiApplicationException.java
+++ b/src/main/java/spring/memewikibe/support/error/MemeWikiApplicationException.java
@@ -1,5 +1,8 @@
 package spring.memewikibe.support.error;
 
+import lombok.Getter;
+
+@Getter
 public class MemeWikiApplicationException extends RuntimeException {
     private final ErrorType errorType;
     private final Object data;
@@ -14,14 +17,6 @@ public class MemeWikiApplicationException extends RuntimeException {
         super(errorType.getMessage());
         this.errorType = errorType;
         this.data = data;
-    }
-
-    public ErrorType getErrorType() {
-        return errorType;
-    }
-
-    public Object getData() {
-        return data;
     }
 
 }

--- a/src/test/java/spring/memewikibe/application/MemeAggregationLookUpServiceImplTest.java
+++ b/src/test/java/spring/memewikibe/application/MemeAggregationLookUpServiceImplTest.java
@@ -1,0 +1,112 @@
+package spring.memewikibe.application;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+import spring.memewikibe.domain.meme.Meme;
+import spring.memewikibe.domain.meme.MemeShareLog;
+import spring.memewikibe.infrastructure.MemeRepository;
+import spring.memewikibe.infrastructure.MemeShareLogRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@SpringBootTest
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class MemeAggregationLookUpServiceImplTest {
+
+    private final MemeAggregationLookUpServiceImpl sut;
+    private final MemeRepository memeRepository;
+    private final MemeShareLogRepository shareLogRepository;
+
+    MemeAggregationLookUpServiceImplTest(MemeAggregationLookUpServiceImpl sut, MemeRepository memeRepository, MemeShareLogRepository shareLogRepository) {
+        this.sut = sut;
+        this.memeRepository = memeRepository;
+        this.shareLogRepository = shareLogRepository;
+    }
+
+    @AfterEach
+    void tearDown() {
+        shareLogRepository.deleteAllInBatch();
+        memeRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 공유수가_높은_밈을_조회한다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+        Meme 전남친_토스트 = createMeme("전남친 토스트");
+        Meme 맑은_눈의_광인 = createMeme("맑은 눈의 광인");
+
+        memeRepository.saveAll(List.of(무야호, 나만_아니면_돼, 전남친_토스트, 맑은_눈의_광인));
+
+        shareLogRepository.saveAll(List.of(
+            createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트),
+            createMemeShareLog(무야호), createMemeShareLog(무야호),
+            createMemeShareLog(맑은_눈의_광인)
+        ));
+
+        // when
+        List<MemeSimpleResponse> response = sut.getMostFrequentSharedMemes();
+
+        // then
+        then(response).hasSize(3)
+            .extracting(MemeSimpleResponse::title)
+            .containsExactly("전남친 토스트", "무야호", "맑은 눈의 광인");
+    }
+
+    @Test
+    void 동일한_공유수일_때_id가_높은순으로_정렬된다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+        Meme 전남친_토스트 = createMeme("전남친 토스트");
+
+        memeRepository.saveAll(List.of(무야호, 나만_아니면_돼, 전남친_토스트));
+
+        shareLogRepository.saveAll(List.of(
+            createMemeShareLog(무야호), createMemeShareLog(무야호),
+            createMemeShareLog(나만_아니면_돼), createMemeShareLog(나만_아니면_돼),
+            createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트)
+        ));
+
+        // when
+        List<MemeSimpleResponse> response = sut.getMostFrequentSharedMemes();
+
+        // then
+        then(response).hasSize(3);
+        // ID가 높은 순서로 정렬되어야 함 (저장 순서의 역순)
+        then(response.get(0).title()).isEqualTo("전남친 토스트");
+        then(response.get(1).title()).isEqualTo("나만 아니면 돼");
+        then(response.get(2).title()).isEqualTo("무야호");
+    }
+
+    private Meme createMeme(String name) {
+        return Meme.builder()
+            .title(name)
+            .origin("origin_" + name)
+            .usageContext("usageContext_" + name)
+            .trendPeriod("trendPeriod_" + name)
+            .imgUrl("imgUrl_" + name)
+            .hashtags("#" + name)
+            .build();
+    }
+
+    private List<Meme> createMemes(int count) {
+        return java.util.stream.IntStream.range(0, count)
+            .mapToObj(i -> createMeme("밈_" + i))
+            .toList();
+    }
+
+    private MemeShareLog createMemeShareLog(Meme meme) {
+        return MemeShareLog.builder()
+            .meme(meme)
+            .build();
+    }
+}

--- a/src/test/java/spring/memewikibe/application/MemeLookUpServiceImplTest.java
+++ b/src/test/java/spring/memewikibe/application/MemeLookUpServiceImplTest.java
@@ -13,12 +13,15 @@ import spring.memewikibe.domain.meme.MemeCategory;
 import spring.memewikibe.infrastructure.CategoryRepository;
 import spring.memewikibe.infrastructure.MemeCategoryRepository;
 import spring.memewikibe.infrastructure.MemeRepository;
+import spring.memewikibe.support.error.ErrorType;
+import spring.memewikibe.support.error.MemeWikiApplicationException;
 import spring.memewikibe.support.response.Cursor;
 import spring.memewikibe.support.response.PageResponse;
 
 import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 @Transactional
 @SpringBootTest
@@ -171,5 +174,78 @@ class MemeLookUpServiceImplTest {
         then(response.getResults()).isEmpty();
         then(response.getPaging().isHasMore()).isFalse();
         then(response.getPaging().getNext()).isNull();
+    }
+
+    @Test
+    void 밈을_단건_조회한다() {
+        // given
+        Meme 나만_아니면_돼 = Meme.builder()
+            .title("나만 아니면 돼")
+            .origin("KBS 2TV '1박 2일'의 복불복 게임에서 벌칙에 걸리지 않은 멤버들이 외치던 말에서 유래했습니다. 초창기 멤버 노홍철이 처음 사용했으며, 이후 강호동이 과장된 표정과 액션으로 외치며 짤방으로 널리 퍼졌습니다. 무한도전의 '무한이기주의'와 비교되며 승리자의 자축을 넘어 타인의 불행을 조롱하는 의미로 변모했습니다.")
+            .usageContext("원래는 복불복에서 살아남은 자의 자축이었으나, 시간이 지나며 타인의 불행을 보고 자신은 괜찮다며 조롱하는 용법으로 사용됩니다. 인터넷 커뮤니티에서 고소 사건, 단체 손해, 가해자 특정, 지탄받는 대상의 천벌 등 남의 불행에 연루되지 않은 사람들이 이를 비웃을 때 쓰입니다. 2020년대 이후 '알빠노' 등 극단적 이기주의 밈의 시초격으로 인식됩니다.")
+            .trendPeriod("2020")
+            .hashtags("\"[\"\"1박2일\"\", \"\"복불복\"\", \"\"노홍철\"\", \"\"강호동\"\", \"\"이기주의\"\", \"\"남의불행\"\", \"\"짤방\"\", \"\"인터넷밈\"\", \"\"알빠노\"\"]\"")
+            .build();
+        Meme 원영적_사고 = Meme.builder()
+            .title("원영적 사고")
+            .origin("장원영의 평소 초긍정적 사고방식이 팬들 사이에서 알려져 있었으나, 2024년 3월 15일 팬 계정의 프메 패러디 트윗이 SNS에 퍼지며 대중화되었습니다. 이후 기업 세미나에 등장하며 확산되었고, 그녀의 긍정적 태도가 악플 속에서도 빛나며 큰 공감을 얻었습니다. '럭키비키'는 핵심 문구입니다.")
+            .usageContext("자신에게 일어나는 모든 일이 결국 긍정적인 결과로 이어질 것이라는 초월적인 낙관주의를 표현할 때 사용됩니다. 부정적인 상황을 단순히 외면하는 것이 아니라, 현재의 어려움도 결국 자신을 성장시키는 과정으로 받아들이며 긍정적으로 치환하는 사고방식입니다. \"\"완전 럭키비키잖아~\"\"와 함께 쓰입니다.")
+            .trendPeriod("2024")
+            .hashtags("\"[\"\"장원영\"\", \"\"원영적사고\"\", \"\"럭키비키\"\", \"\"초긍정\"\", \"\"긍정적사고\"\", \"\"인터넷밈\"\", \"\"아이브\"\"]\"")
+            .build();
+        Meme 무야호 = Meme.builder()
+            .title("무야호")
+            .origin("2010년 MBC 예능 프로그램 '무한도전' 알래스카 특집에서 유재석, 정형돈, 노홍철이 현지 교민 최규재 할아버지에게 '무한~도전!' 구호를 요청하자, 할아버지가 당황하며 '무야~ 호~!'라고 외친 장면에서 유래했습니다. 방영 당시에는 큰 주목을 받지 못했으나, 2018년 이후 유튜브 알고리즘과 팬 페이지를 통해 재발견되며 폭발적인 인기를 얻었습니다.")
+            .usageContext("예상치 못한 상황에서 터져 나오는 순수한 기쁨, 환희, 또는 놀라움을 표현할 때 사용됩니다. 때로는 상황이 다소 어이없거나 엉뚱할 때의 유쾌함을 나타내기도 합니다. 특정 인물이나 상황에 대한 비난 또는 칭찬의 맥락에서도 사용될 수 있으며, 전반적으로 긍정적이고 유쾌한 분위기를 조성하는 데 활용됩니다.")
+            .trendPeriod("2018")
+            .hashtags("\"[\"\"무한도전\"\", \"\"무야호\"\", \"\"최규재\"\", \"\"알래스카\"\", \"\"인터넷밈\"\", \"\"유행어\"\", \"\"환희\"\", \"\"기쁨\"\", \"\"감탄사\"\"]\"")
+            .build();
+
+        memeRepository.saveAll(List.of(나만_아니면_돼, 원영적_사고, 무야호));
+
+        // when
+        MemeDetailResponse response = memeLookUpService.getMemeById(나만_아니면_돼.getId());
+
+        // then
+        then(response).extracting(MemeDetailResponse::title, MemeDetailResponse::origin, MemeDetailResponse::usageContext, MemeDetailResponse::trendPeriod, MemeDetailResponse::hashtags)
+            .containsExactly("나만 아니면 돼",
+                "KBS 2TV '1박 2일'의 복불복 게임에서 벌칙에 걸리지 않은 멤버들이 외치던 말에서 유래했습니다. 초창기 멤버 노홍철이 처음 사용했으며, 이후 강호동이 과장된 표정과 액션으로 외치며 짤방으로 널리 퍼졌습니다. 무한도전의 '무한이기주의'와 비교되며 승리자의 자축을 넘어 타인의 불행을 조롱하는 의미로 변모했습니다.",
+                "원래는 복불복에서 살아남은 자의 자축이었으나, 시간이 지나며 타인의 불행을 보고 자신은 괜찮다며 조롱하는 용법으로 사용됩니다. 인터넷 커뮤니티에서 고소 사건, 단체 손해, 가해자 특정, 지탄받는 대상의 천벌 등 남의 불행에 연루되지 않은 사람들이 이를 비웃을 때 쓰입니다. 2020년대 이후 '알빠노' 등 극단적 이기주의 밈의 시초격으로 인식됩니다.",
+                "2020",
+                "\"[\"\"1박2일\"\", \"\"복불복\"\", \"\"노홍철\"\", \"\"강호동\"\", \"\"이기주의\"\", \"\"남의불행\"\", \"\"짤방\"\", \"\"인터넷밈\"\", \"\"알빠노\"\"]\""
+            );
+    }
+
+    @Test
+    void 존재하지_않는_밈을_조회하면_예외를_발생한다() {
+        Meme 나만_아니면_돼 = Meme.builder()
+            .title("나만 아니면 돼")
+            .origin("KBS 2TV '1박 2일'의 복불복 게임에서 벌칙에 걸리지 않은 멤버들이 외치던 말에서 유래했습니다. 초창기 멤버 노홍철이 처음 사용했으며, 이후 강호동이 과장된 표정과 액션으로 외치며 짤방으로 널리 퍼졌습니다. 무한도전의 '무한이기주의'와 비교되며 승리자의 자축을 넘어 타인의 불행을 조롱하는 의미로 변모했습니다.")
+            .usageContext("원래는 복불복에서 살아남은 자의 자축이었으나, 시간이 지나며 타인의 불행을 보고 자신은 괜찮다며 조롱하는 용법으로 사용됩니다. 인터넷 커뮤니티에서 고소 사건, 단체 손해, 가해자 특정, 지탄받는 대상의 천벌 등 남의 불행에 연루되지 않은 사람들이 이를 비웃을 때 쓰입니다. 2020년대 이후 '알빠노' 등 극단적 이기주의 밈의 시초격으로 인식됩니다.")
+            .trendPeriod("2020")
+            .hashtags("\"[\"\"1박2일\"\", \"\"복불복\"\", \"\"노홍철\"\", \"\"강호동\"\", \"\"이기주의\"\", \"\"남의불행\"\", \"\"짤방\"\", \"\"인터넷밈\"\", \"\"알빠노\"\"]\"")
+            .build();
+        Meme 원영적_사고 = Meme.builder()
+            .title("원영적 사고")
+            .origin("장원영의 평소 초긍정적 사고방식이 팬들 사이에서 알려져 있었으나, 2024년 3월 15일 팬 계정의 프메 패러디 트윗이 SNS에 퍼지며 대중화되었습니다. 이후 기업 세미나에 등장하며 확산되었고, 그녀의 긍정적 태도가 악플 속에서도 빛나며 큰 공감을 얻었습니다. '럭키비키'는 핵심 문구입니다.")
+            .usageContext("자신에게 일어나는 모든 일이 결국 긍정적인 결과로 이어질 것이라는 초월적인 낙관주의를 표현할 때 사용됩니다. 부정적인 상황을 단순히 외면하는 것이 아니라, 현재의 어려움도 결국 자신을 성장시키는 과정으로 받아들이며 긍정적으로 치환하는 사고방식입니다. \"\"완전 럭키비키잖아~\"\"와 함께 쓰입니다.")
+            .trendPeriod("2024")
+            .hashtags("\"[\"\"장원영\"\", \"\"원영적사고\"\", \"\"럭키비키\"\", \"\"초긍정\"\", \"\"긍정적사고\"\", \"\"인터넷밈\"\", \"\"아이브\"\"]\"")
+            .build();
+        Meme 무야호 = Meme.builder()
+            .title("무야호")
+            .origin("2010년 MBC 예능 프로그램 '무한도전' 알래스카 특집에서 유재석, 정형돈, 노홍철이 현지 교민 최규재 할아버지에게 '무한~도전!' 구호를 요청하자, 할아버지가 당황하며 '무야~ 호~!'라고 외친 장면에서 유래했습니다. 방영 당시에는 큰 주목을 받지 못했으나, 2018년 이후 유튜브 알고리즘과 팬 페이지를 통해 재발견되며 폭발적인 인기를 얻었습니다.")
+            .usageContext("예상치 못한 상황에서 터져 나오는 순수한 기쁨, 환희, 또는 놀라움을 표현할 때 사용됩니다. 때로는 상황이 다소 어이없거나 엉뚱할 때의 유쾌함을 나타내기도 합니다. 특정 인물이나 상황에 대한 비난 또는 칭찬의 맥락에서도 사용될 수 있으며, 전반적으로 긍정적이고 유쾌한 분위기를 조성하는 데 활용됩니다.")
+            .trendPeriod("2018")
+            .hashtags("\"[\"\"무한도전\"\", \"\"무야호\"\", \"\"최규재\"\", \"\"알래스카\"\", \"\"인터넷밈\"\", \"\"유행어\"\", \"\"환희\"\", \"\"기쁨\"\", \"\"감탄사\"\"]\"")
+            .build();
+
+        memeRepository.saveAll(List.of(나만_아니면_돼, 원영적_사고, 무야호));
+
+        // when & then
+        thenThrownBy(() -> memeLookUpService.getMemeById(999L))
+            .isInstanceOf(MemeWikiApplicationException.class)
+            .extracting(exception -> ((MemeWikiApplicationException) exception).getErrorType())
+            .isEqualTo(ErrorType.MEME_NOT_FOUND);
     }
 }

--- a/src/test/java/spring/memewikibe/infrastructure/MemeCategoryRepositoryTest.java
+++ b/src/test/java/spring/memewikibe/infrastructure/MemeCategoryRepositoryTest.java
@@ -3,16 +3,19 @@ package spring.memewikibe.infrastructure;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Description;
 import org.springframework.data.domain.Limit;
 import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import spring.memewikibe.domain.meme.Category;
 import spring.memewikibe.domain.meme.Meme;
 import spring.memewikibe.domain.meme.MemeCategory;
 
 import java.util.List;
 
-@DataJpaTest
+@SpringBootTest
+@Transactional
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class MemeCategoryRepositoryTest {
 

--- a/src/test/java/spring/memewikibe/infrastructure/MemeCustomLogRepositoryTest.java
+++ b/src/test/java/spring/memewikibe/infrastructure/MemeCustomLogRepositoryTest.java
@@ -1,0 +1,100 @@
+package spring.memewikibe.infrastructure;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+import spring.memewikibe.domain.meme.Meme;
+import spring.memewikibe.domain.meme.MemeCustomLog;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@SpringBootTest
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class MemeCustomLogRepositoryTest {
+
+    private final MemeCustomLogRepository sut;
+    private final MemeRepository memeRepository;
+
+    MemeCustomLogRepositoryTest(MemeCustomLogRepository sut, MemeRepository memeRepository) {
+        this.sut = sut;
+        this.memeRepository = memeRepository;
+    }
+
+    @AfterEach
+    void tearDown() {
+        sut.deleteAllInBatch();
+        memeRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 기간별_커스텀_횟수가_높은순으로_조회한다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+        Meme 전남친_토스트 = createMeme("전남친 토스트");
+        Meme 맑은_눈의_광인 = createMeme("맑은 눈의 광인");
+
+        memeRepository.saveAll(List.of(무야호, 나만_아니면_돼, 전남친_토스트, 맑은_눈의_광인));
+
+        sut.saveAll(List.of(createMemeCustomLog(전남친_토스트), createMemeCustomLog(전남친_토스트), createMemeCustomLog(전남친_토스트),
+            createMemeCustomLog(무야호), createMemeCustomLog(무야호),
+            createMemeCustomLog(맑은_눈의_광인)
+        ));
+
+        // when
+        List<MemeSimpleResponse> result = sut.findTopMemesByCustomCountWithin(Duration.ofDays(1), 2);
+
+        // then
+        then(result).hasSize(2)
+            .extracting(MemeSimpleResponse::title)
+            .containsExactlyInAnyOrder("전남친 토스트", "무야호");
+    }
+
+    @Test
+    void findTopMemesByCustomCountWithin_메서드는_동일한_카운트를_가질_때_id가_높은순으로_조회된다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+        Meme 전남친_토스트 = createMeme("전남친 토스트");
+        Meme 맑은_눈의_광인 = createMeme("맑은 눈의 광인");
+
+        memeRepository.saveAll(List.of(무야호, 나만_아니면_돼, 전남친_토스트, 맑은_눈의_광인));
+
+        sut.saveAll(List.of(createMemeCustomLog(전남친_토스트), createMemeCustomLog(전남친_토스트), createMemeCustomLog(전남친_토스트),
+            createMemeCustomLog(무야호), createMemeCustomLog(무야호),
+            createMemeCustomLog(맑은_눈의_광인), createMemeCustomLog(맑은_눈의_광인)
+        ));
+
+        // when
+        List<MemeSimpleResponse> result = sut.findTopMemesByCustomCountWithin(Duration.ofDays(1), 2);
+
+        // then
+        then(result).hasSize(2)
+            .extracting(MemeSimpleResponse::title)
+            .containsExactlyInAnyOrder("전남친 토스트", "맑은 눈의 광인");
+    }
+
+    private Meme createMeme(String name) {
+        return Meme.builder()
+            .title(name)
+            .origin("origin_" + name)
+            .usageContext("usageContext_" + name)
+            .trendPeriod("trendPeriod_" + name)
+            .imgUrl("imgUrl_" + name)
+            .hashtags("#" + name)
+            .build();
+    }
+
+    private MemeCustomLog createMemeCustomLog(Meme meme) {
+        return MemeCustomLog.builder()
+            .meme(meme)
+            .build();
+    }
+}

--- a/src/test/java/spring/memewikibe/infrastructure/MemeRepositoryTest.java
+++ b/src/test/java/spring/memewikibe/infrastructure/MemeRepositoryTest.java
@@ -1,0 +1,146 @@
+package spring.memewikibe.infrastructure;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import spring.memewikibe.domain.meme.*;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@SpringBootTest
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class MemeRepositoryTest {
+
+    private final MemeRepository sut;
+    private final MemeCustomLogRepository customLogRepository;
+    private final MemeShareLogRepository shareLogRepository;
+    private final MemeViewLogRepository viewLogRepository;
+
+    MemeRepositoryTest(MemeRepository sut,
+                       MemeCustomLogRepository customLogRepository,
+                       MemeShareLogRepository shareLogRepository,
+                       MemeViewLogRepository viewLogRepository) {
+        this.sut = sut;
+        this.customLogRepository = customLogRepository;
+        this.shareLogRepository = shareLogRepository;
+        this.viewLogRepository = viewLogRepository;
+    }
+
+    @AfterEach
+    void tearDown() {
+        customLogRepository.deleteAllInBatch();
+        shareLogRepository.deleteAllInBatch();
+        viewLogRepository.deleteAllInBatch();
+        sut.deleteAllInBatch();
+    }
+
+    @Test
+    void 가중치를_적용한_인기도순으로_밈을_조회한다() {
+        // given
+        // 가중치 적용: custom 3점, share 2점, view 1점
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+        Meme 전남친_토스트 = createMeme("전남친 토스트");
+        Meme 맑은_눈의_광인 = createMeme("맑은 눈의 광인");
+
+        sut.saveAll(List.of(무야호, 나만_아니면_돼, 전남친_토스트, 맑은_눈의_광인));
+
+        // 전남친 토스트: custom 1개, share 2개, view 1개 = 8점
+        customLogRepository.save(createMemeCustomLog(전남친_토스트));
+        shareLogRepository.saveAll(List.of(createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트)));
+        viewLogRepository.save(createMemeViewLog(전남친_토스트));
+
+        // 무야호: custom 2개, view 1개 = 7점
+        customLogRepository.saveAll(List.of(createMemeCustomLog(무야호), createMemeCustomLog(무야호)));
+        viewLogRepository.save(createMemeViewLog(무야호));
+
+        // 나만 아니면 돼: share 1개, view 3개 = 6점
+        shareLogRepository.save(createMemeShareLog(나만_아니면_돼));
+        viewLogRepository.saveAll(List.of(createMemeViewLog(나만_아니면_돼), createMemeViewLog(나만_아니면_돼), createMemeViewLog(나만_아니면_돼)));
+
+        // 맑은 눈의 광인: custom 3개 = 9점
+        customLogRepository.saveAll(List.of(createMemeCustomLog(맑은_눈의_광인), createMemeCustomLog(맑은_눈의_광인), createMemeCustomLog(맑은_눈의_광인)));
+
+        // when
+        List<MemeAggregationResult> result = sut.findTopRatedMemesBy(Duration.ofDays(1), 3);
+
+        then(result).hasSize(3)
+            .extracting(MemeAggregationResult::title)
+            .containsExactly("맑은 눈의 광인", "전남친 토스트", "무야호");
+    }
+
+    @Test
+    void 동일한_가중치_점수일때_id가_높은순으로_조회한다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+
+        sut.saveAll(List.of(무야호, 나만_아니면_돼));
+
+        // 둘 다 custom 1개씩 = 3점
+        customLogRepository.saveAll(List.of(createMemeCustomLog(무야호), createMemeCustomLog(나만_아니면_돼)));
+
+        // when
+        List<MemeAggregationResult> result = sut.findTopRatedMemesBy(Duration.ofDays(1), 2);
+
+        // then - 동점일 때 id가 높은 순 (나만_아니면_돼가 나중에 생성되어 id가 더 큼)
+        then(result).hasSize(2)
+            .extracting(MemeAggregationResult::title)
+            .containsExactly("나만 아니면 돼", "무야호");
+    }
+
+    @Test
+    void 로그가_없는_밈도_결과에_포함된다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 로그없는밈 = createMeme("로그없는밈");
+
+        sut.saveAll(List.of(무야호, 로그없는밈));
+
+        // 무야호만 로그 추가
+        customLogRepository.save(createMemeCustomLog(무야호));
+
+        // when
+        List<MemeAggregationResult> result = sut.findTopRatedMemesBy(Duration.ofDays(1), 5);
+
+        // then - 로그 없는 밈도 포함 (0점으로 처리)
+        then(result).hasSize(2)
+            .extracting(MemeAggregationResult::title)
+            .containsExactly("무야호", "로그없는밈");
+    }
+
+    private Meme createMeme(String name) {
+        return Meme.builder()
+            .title(name)
+            .origin("origin_" + name)
+            .usageContext("usageContext_" + name)
+            .trendPeriod("trendPeriod_" + name)
+            .imgUrl("imgUrl_" + name)
+            .hashtags("#" + name)
+            .build();
+    }
+
+    private MemeCustomLog createMemeCustomLog(Meme meme) {
+        return MemeCustomLog.builder()
+            .meme(meme)
+            .build();
+    }
+
+    private MemeShareLog createMemeShareLog(Meme meme) {
+        return MemeShareLog.builder()
+            .meme(meme)
+            .build();
+    }
+
+    private MemeViewLog createMemeViewLog(Meme meme) {
+        return MemeViewLog.builder()
+            .meme(meme)
+            .build();
+    }
+}

--- a/src/test/java/spring/memewikibe/infrastructure/MemeShareLogRepositoryTest.java
+++ b/src/test/java/spring/memewikibe/infrastructure/MemeShareLogRepositoryTest.java
@@ -1,0 +1,98 @@
+package spring.memewikibe.infrastructure;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+import spring.memewikibe.domain.meme.Meme;
+import spring.memewikibe.domain.meme.MemeShareLog;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@SpringBootTest
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class MemeShareLogRepositoryTest {
+
+    private final MemeShareLogRepository sut;
+    private final MemeRepository memeRepository;
+
+    MemeShareLogRepositoryTest(MemeShareLogRepository sut, MemeRepository memeRepository) {
+        this.sut = sut;
+        this.memeRepository = memeRepository;
+    }
+
+    @AfterEach
+    void tearDown() {
+        sut.deleteAllInBatch();
+        memeRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 기간별_공유_횟수가_높은순으로_조회한다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+        Meme 전남친_토스트 = createMeme("전남친 토스트");
+        Meme 맑은_눈의_광인 = createMeme("맑은 눈의 광인");
+
+        memeRepository.saveAll(List.of(무야호, 나만_아니면_돼, 전남친_토스트, 맑은_눈의_광인));
+
+        sut.saveAll(List.of(createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트),
+            createMemeShareLog(무야호), createMemeShareLog(무야호),
+            createMemeShareLog(맑은_눈의_광인)
+        ));
+
+        // when
+        List<MemeSimpleResponse> result = sut.findTopMemesByShareCountWithin(Duration.ofDays(1), 2);
+        // then
+        then(result).hasSize(2)
+            .extracting(MemeSimpleResponse::title)
+            .containsExactlyInAnyOrder("전남친 토스트", "무야호");
+    }
+
+    @Test
+    void findTopMemesByShareCountWithin_메서드는_동일한_카운트를_가질_때_id가_높은순으로_조회된다() {
+        // given
+        Meme 무야호 = createMeme("무야호");
+        Meme 나만_아니면_돼 = createMeme("나만 아니면 돼");
+        Meme 전남친_토스트 = createMeme("전남친 토스트");
+        Meme 맑은_눈의_광인 = createMeme("맑은 눈의 광인");
+
+        memeRepository.saveAll(List.of(무야호, 나만_아니면_돼, 전남친_토스트, 맑은_눈의_광인));
+
+        sut.saveAll(List.of(createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트), createMemeShareLog(전남친_토스트),
+            createMemeShareLog(무야호), createMemeShareLog(무야호),
+            createMemeShareLog(맑은_눈의_광인), createMemeShareLog(맑은_눈의_광인)
+        ));
+
+        // when
+        List<MemeSimpleResponse> result = sut.findTopMemesByShareCountWithin(Duration.ofDays(1), 2);
+        // then
+        then(result).hasSize(2)
+            .extracting(MemeSimpleResponse::title)
+            .containsExactlyInAnyOrder("전남친 토스트", "맑은 눈의 광인");
+    }
+
+    private Meme createMeme(String name) {
+        return Meme.builder()
+            .title(name)
+            .origin("origin_" + name)
+            .usageContext("usageContext_" + name)
+            .trendPeriod("trendPeriod_" + name)
+            .imgUrl("imgUrl_" + name)
+            .hashtags("#" + name)
+            .build();
+    }
+
+    private MemeShareLog createMemeShareLog(Meme meme) {
+        return MemeShareLog.builder()
+            .meme(meme)
+            .build();
+    }
+}


### PR DESCRIPTION
# 구현사항
- 공유수 기반 인기순 조회
- 나만의 밈 제작 기반 인기순 조회
- 종합 스코어링 인기순 조회

# 고민사항
- 종합 스코어링 스코어를 제 맘대로 했습니다 괜찮을까요 ?
- 조회 기간도 제 맘대로 했습니다 괜찮을까요 ?
- 그리고 제 생각에 종합스코어링은 메모리에 올려두고 일정 기간마다 갱신해주면 될 것 같은데 나머지는 그냥 직접 반환해도 성능상 문제가 되진않을 것 같아서 일단은 요대로 가도 괜찮겠죠 ?(종합스코어링은 메모리에 올리는거 추가하겠습니다)
- 어플리케이션에서 처리하는게 아니라 쿼리로 처리했는데 이게 더 나아 보이긴해서 선택했는데 괜찮겠져 ?
- 가중치가 쿼리문에 있는게 좀 거슬리긴하는데 괜찮겠죠..? 외부에서 주입받아야되나 싶기도 한데 지금 단계에서는 넘어가도 될 것 같기도 합니다

# 공유사항
- 제가 테스트의 변수를 한글로써서(밈들을 영어로쓰자니 애매해서) 쪼금 불편하실수도 있어여 ㅎㅎ
- 요거 lookup-category-meme브랜치에서 rebase해서 시작한거라 pr을 그쪽으로 붙일게요