### PR TITLE
밈을 검색하고 상세내용을 조회한다

### DIFF
--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -29,13 +29,12 @@ public class MemeController {
     }
 
     @GetMapping
-    public ApiResponse<PageResponse<Cursor, MemeSimpleResponse>> getMemes(
+    public ApiResponse<PageResponse<Cursor, MemeDetailResponse>> getMemes(
         @RequestParam(required = false) Long next,
         @RequestParam(required = false) String query,
         @RequestParam(required = false, defaultValue = "20") int limit
     ) {
-        // TODO: 검색 및 전체조회
-        return null;
+        return ApiResponse.success(memeLookUpService.getMemesByQuery(query, next, limit));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -41,8 +41,7 @@ public class MemeController {
     public ApiResponse<MemeDetailResponse> getMeme(
         @PathVariable Long id
     ) {
-        // TODO: 상세 조회
-        return null;
+        return ApiResponse.success(memeLookUpService.getMemeById(id));
     }
 
     @ResponseStatus(HttpStatus.ACCEPTED)

--- a/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
@@ -1,10 +1,15 @@
 package spring.memewikibe.application;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 import spring.memewikibe.domain.meme.Meme;
 import spring.memewikibe.domain.meme.MemeCustomLog;
 import spring.memewikibe.domain.meme.MemeShareLog;
 import spring.memewikibe.domain.meme.MemeViewLog;
+import spring.memewikibe.domain.meme.event.MemeViewedEvent;
 import spring.memewikibe.infrastructure.MemeCustomLogRepository;
 import spring.memewikibe.infrastructure.MemeRepository;
 import spring.memewikibe.infrastructure.MemeShareLogRepository;
@@ -44,6 +49,13 @@ public class MemeAggregationServiceImpl implements MemeAggregationService {
     public void increaseShareMemeCount(Long memeId) {
         Meme meme = getMemeBy(memeId);
         memeShareLogRepository.save(MemeShareLog.of(meme));
+    }
+
+    @Async
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleMemeViewed(MemeViewedEvent event) {
+        increaseMemeViewCount(event.memeId());
     }
 
     private Meme getMemeBy(Long memeId) {

--- a/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationServiceImpl.java
@@ -11,7 +11,7 @@ import spring.memewikibe.infrastructure.MemeShareLogRepository;
 import spring.memewikibe.infrastructure.MemeViewLogRepository;
 import spring.memewikibe.support.error.MemeWikiApplicationException;
 
-import static spring.memewikibe.support.error.ErrorType.MEME_NOT_FOUNT;
+import static spring.memewikibe.support.error.ErrorType.MEME_NOT_FOUND;
 
 @Service
 public class MemeAggregationServiceImpl implements MemeAggregationService {
@@ -47,6 +47,6 @@ public class MemeAggregationServiceImpl implements MemeAggregationService {
     }
 
     private Meme getMemeBy(Long memeId) {
-        return memeRepository.findById(memeId).orElseThrow(() -> new MemeWikiApplicationException(MEME_NOT_FOUNT));
+        return memeRepository.findById(memeId).orElseThrow(() -> new MemeWikiApplicationException(MEME_NOT_FOUND));
     }
 }

--- a/src/main/java/spring/memewikibe/application/MemeLookUpService.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpService.java
@@ -11,4 +11,6 @@ public interface MemeLookUpService {
     List<CategoryResponse> getAllCategories();
 
     PageResponse<Cursor, MemeDetailResponse> getMemesByCategory(Long id, Long next, int limit);
+
+    PageResponse<Cursor, MemeDetailResponse> getMemesByQuery(String query, Long next, int limit);
 }

--- a/src/main/java/spring/memewikibe/application/MemeLookUpService.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpService.java
@@ -13,4 +13,6 @@ public interface MemeLookUpService {
     PageResponse<Cursor, MemeDetailResponse> getMemesByCategory(Long id, Long next, int limit);
 
     PageResponse<Cursor, MemeDetailResponse> getMemesByQuery(String query, Long next, int limit);
+
+    MemeDetailResponse getMemeById(Long id);
 }

--- a/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
@@ -60,6 +60,14 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
         return createPageResponseBy(foundMemes, limit);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public MemeDetailResponse getMemeById(Long id) {
+        Meme meme = memeRepository.findById(id)
+            .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUND));
+        return new MemeDetailResponse(meme.getId(), meme.getTitle(), meme.getUsageContext(), meme.getOrigin(), meme.getTrendPeriod(), meme.getImgUrl(), meme.getHashtags());
+    }
+
     private PageResponse<Cursor, MemeDetailResponse> createPageResponseBy(List<Meme> memes, int limit) {
         Cursor cursor = Cursor.of(memes, limit);
         List<MemeDetailResponse> response = memes.stream()
@@ -83,7 +91,7 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
         }
 
         Meme meme = memeRepository.findById(next)
-            .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUNT));
+            .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUND));
         return memeCategoryRepository.findByCategoryAndMemeGreaterThanOrderByMemeAsc(category, meme, Limit.of(limit + 1))
             .stream()
             .map(MemeCategory::getMeme)

--- a/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
@@ -1,5 +1,6 @@
 package spring.memewikibe.application;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +9,7 @@ import spring.memewikibe.api.controller.meme.response.MemeDetailResponse;
 import spring.memewikibe.domain.meme.Category;
 import spring.memewikibe.domain.meme.Meme;
 import spring.memewikibe.domain.meme.MemeCategory;
+import spring.memewikibe.domain.meme.event.MemeViewedEvent;
 import spring.memewikibe.infrastructure.CategoryRepository;
 import spring.memewikibe.infrastructure.MemeCategoryRepository;
 import spring.memewikibe.infrastructure.MemeRepository;
@@ -24,11 +26,13 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
     private final CategoryRepository categoryRepository;
     private final MemeRepository memeRepository;
     private final MemeCategoryRepository memeCategoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public MemeLookUpServiceImpl(CategoryRepository categoryRepository, MemeRepository memeRepository, MemeCategoryRepository memeCategoryRepository) {
+    public MemeLookUpServiceImpl(CategoryRepository categoryRepository, MemeRepository memeRepository, MemeCategoryRepository memeCategoryRepository, ApplicationEventPublisher eventPublisher) {
         this.categoryRepository = categoryRepository;
         this.memeRepository = memeRepository;
         this.memeCategoryRepository = memeCategoryRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -65,6 +69,9 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
     public MemeDetailResponse getMemeById(Long id) {
         Meme meme = memeRepository.findById(id)
             .orElseThrow(() -> new MemeWikiApplicationException(ErrorType.MEME_NOT_FOUND));
+
+        eventPublisher.publishEvent(new MemeViewedEvent(id));
+
         return new MemeDetailResponse(meme.getId(), meme.getTitle(), meme.getUsageContext(), meme.getOrigin(), meme.getTrendPeriod(), meme.getImgUrl(), meme.getHashtags());
     }
 

--- a/src/main/java/spring/memewikibe/config/AsyncConfig.java
+++ b/src/main/java/spring/memewikibe/config/AsyncConfig.java
@@ -1,0 +1,74 @@
+package spring.memewikibe.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
+    public ThreadPoolTaskExecutor asyncTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        int cpuCores = Runtime.getRuntime().availableProcessors();
+        executor.setCorePoolSize(cpuCores);
+        executor.setMaxPoolSize(cpuCores);
+        executor.setThreadNamePrefix("async");
+        executor.setQueueCapacity(1_000);
+        executor.setAwaitTerminationSeconds(5);
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setTaskDecorator(new MdcTaskDecorator());
+        executor.initialize();
+        executor.getThreadPoolExecutor().prestartAllCoreThreads();
+        return executor;
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return asyncTaskExecutor();
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncExceptionHandler();
+    }
+
+    @Slf4j
+    private static class AsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+        @Override
+        public void handleUncaughtException(Throwable throwable, Method method, Object... objects) {
+            log.error("Error on async execution: ", throwable);
+        }
+    }
+
+    private static class MdcTaskDecorator implements TaskDecorator {
+
+        @Override
+        public Runnable decorate(Runnable runnable) {
+            Map<String, String> contextMap = MDC.getCopyOfContextMap();
+            return () -> {
+                try {
+                    if (contextMap != null) {
+                        MDC.setContextMap(contextMap);
+                    }
+                    runnable.run();
+                } finally {
+                    MDC.clear();
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/spring/memewikibe/domain/meme/event/MemeViewedEvent.java
+++ b/src/main/java/spring/memewikibe/domain/meme/event/MemeViewedEvent.java
@@ -1,0 +1,4 @@
+package spring.memewikibe.domain.meme.event;
+
+public record MemeViewedEvent(Long memeId) {
+}

--- a/src/main/java/spring/memewikibe/infrastructure/MemeRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeRepository.java
@@ -1,7 +1,13 @@
 package spring.memewikibe.infrastructure;
 
+import org.springframework.data.domain.Limit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.memewikibe.domain.meme.Meme;
 
+import java.util.List;
+
 public interface MemeRepository extends JpaRepository<Meme, Long>, MemeAggregationRepository {
+    List<Meme> findByTitleContainingOrderByIdDesc(String title, Limit limit);
+
+    List<Meme> findByTitleContainingAndIdLessThanOrderByIdDesc(String title, Long id, Limit limit);
 }

--- a/src/main/java/spring/memewikibe/support/error/ErrorType.java
+++ b/src/main/java/spring/memewikibe/support/error/ErrorType.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
     DEFAULT_ERROR(
         HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "예기치 못한 에러가 발생했습니다.", LogLevel.ERROR),
-    MEME_NOT_FOUNT(
+    MEME_NOT_FOUND(
         HttpStatus.NOT_FOUND, ErrorCode.E404, "존재하지 않는 밈입니다.", LogLevel.WARN),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "존재하지 않는 카테고리입니다.", LogLevel.WARN);
 

--- a/src/main/java/spring/memewikibe/support/error/MemeWikiApplicationException.java
+++ b/src/main/java/spring/memewikibe/support/error/MemeWikiApplicationException.java
@@ -1,5 +1,8 @@
 package spring.memewikibe.support.error;
 
+import lombok.Getter;
+
+@Getter
 public class MemeWikiApplicationException extends RuntimeException {
     private final ErrorType errorType;
     private final Object data;
@@ -14,14 +17,6 @@ public class MemeWikiApplicationException extends RuntimeException {
         super(errorType.getMessage());
         this.errorType = errorType;
         this.data = data;
-    }
-
-    public ErrorType getErrorType() {
-        return errorType;
-    }
-
-    public Object getData() {
-        return data;
     }
 
 }

--- a/src/test/java/spring/memewikibe/application/MemeLookUpServiceImplTest.java
+++ b/src/test/java/spring/memewikibe/application/MemeLookUpServiceImplTest.java
@@ -13,12 +13,15 @@ import spring.memewikibe.domain.meme.MemeCategory;
 import spring.memewikibe.infrastructure.CategoryRepository;
 import spring.memewikibe.infrastructure.MemeCategoryRepository;
 import spring.memewikibe.infrastructure.MemeRepository;
+import spring.memewikibe.support.error.ErrorType;
+import spring.memewikibe.support.error.MemeWikiApplicationException;
 import spring.memewikibe.support.response.Cursor;
 import spring.memewikibe.support.response.PageResponse;
 
 import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 @Transactional
 @SpringBootTest
@@ -171,5 +174,78 @@ class MemeLookUpServiceImplTest {
         then(response.getResults()).isEmpty();
         then(response.getPaging().isHasMore()).isFalse();
         then(response.getPaging().getNext()).isNull();
+    }
+
+    @Test
+    void 밈을_단건_조회한다() {
+        // given
+        Meme 나만_아니면_돼 = Meme.builder()
+            .title("나만 아니면 돼")
+            .origin("KBS 2TV '1박 2일'의 복불복 게임에서 벌칙에 걸리지 않은 멤버들이 외치던 말에서 유래했습니다. 초창기 멤버 노홍철이 처음 사용했으며, 이후 강호동이 과장된 표정과 액션으로 외치며 짤방으로 널리 퍼졌습니다. 무한도전의 '무한이기주의'와 비교되며 승리자의 자축을 넘어 타인의 불행을 조롱하는 의미로 변모했습니다.")
+            .usageContext("원래는 복불복에서 살아남은 자의 자축이었으나, 시간이 지나며 타인의 불행을 보고 자신은 괜찮다며 조롱하는 용법으로 사용됩니다. 인터넷 커뮤니티에서 고소 사건, 단체 손해, 가해자 특정, 지탄받는 대상의 천벌 등 남의 불행에 연루되지 않은 사람들이 이를 비웃을 때 쓰입니다. 2020년대 이후 '알빠노' 등 극단적 이기주의 밈의 시초격으로 인식됩니다.")
+            .trendPeriod("2020")
+            .hashtags("\"[\"\"1박2일\"\", \"\"복불복\"\", \"\"노홍철\"\", \"\"강호동\"\", \"\"이기주의\"\", \"\"남의불행\"\", \"\"짤방\"\", \"\"인터넷밈\"\", \"\"알빠노\"\"]\"")
+            .build();
+        Meme 원영적_사고 = Meme.builder()
+            .title("원영적 사고")
+            .origin("장원영의 평소 초긍정적 사고방식이 팬들 사이에서 알려져 있었으나, 2024년 3월 15일 팬 계정의 프메 패러디 트윗이 SNS에 퍼지며 대중화되었습니다. 이후 기업 세미나에 등장하며 확산되었고, 그녀의 긍정적 태도가 악플 속에서도 빛나며 큰 공감을 얻었습니다. '럭키비키'는 핵심 문구입니다.")
+            .usageContext("자신에게 일어나는 모든 일이 결국 긍정적인 결과로 이어질 것이라는 초월적인 낙관주의를 표현할 때 사용됩니다. 부정적인 상황을 단순히 외면하는 것이 아니라, 현재의 어려움도 결국 자신을 성장시키는 과정으로 받아들이며 긍정적으로 치환하는 사고방식입니다. \"\"완전 럭키비키잖아~\"\"와 함께 쓰입니다.")
+            .trendPeriod("2024")
+            .hashtags("\"[\"\"장원영\"\", \"\"원영적사고\"\", \"\"럭키비키\"\", \"\"초긍정\"\", \"\"긍정적사고\"\", \"\"인터넷밈\"\", \"\"아이브\"\"]\"")
+            .build();
+        Meme 무야호 = Meme.builder()
+            .title("무야호")
+            .origin("2010년 MBC 예능 프로그램 '무한도전' 알래스카 특집에서 유재석, 정형돈, 노홍철이 현지 교민 최규재 할아버지에게 '무한~도전!' 구호를 요청하자, 할아버지가 당황하며 '무야~ 호~!'라고 외친 장면에서 유래했습니다. 방영 당시에는 큰 주목을 받지 못했으나, 2018년 이후 유튜브 알고리즘과 팬 페이지를 통해 재발견되며 폭발적인 인기를 얻었습니다.")
+            .usageContext("예상치 못한 상황에서 터져 나오는 순수한 기쁨, 환희, 또는 놀라움을 표현할 때 사용됩니다. 때로는 상황이 다소 어이없거나 엉뚱할 때의 유쾌함을 나타내기도 합니다. 특정 인물이나 상황에 대한 비난 또는 칭찬의 맥락에서도 사용될 수 있으며, 전반적으로 긍정적이고 유쾌한 분위기를 조성하는 데 활용됩니다.")
+            .trendPeriod("2018")
+            .hashtags("\"[\"\"무한도전\"\", \"\"무야호\"\", \"\"최규재\"\", \"\"알래스카\"\", \"\"인터넷밈\"\", \"\"유행어\"\", \"\"환희\"\", \"\"기쁨\"\", \"\"감탄사\"\"]\"")
+            .build();
+
+        memeRepository.saveAll(List.of(나만_아니면_돼, 원영적_사고, 무야호));
+
+        // when
+        MemeDetailResponse response = memeLookUpService.getMemeById(나만_아니면_돼.getId());
+
+        // then
+        then(response).extracting(MemeDetailResponse::title, MemeDetailResponse::origin, MemeDetailResponse::usageContext, MemeDetailResponse::trendPeriod, MemeDetailResponse::hashtags)
+            .containsExactly("나만 아니면 돼",
+                "KBS 2TV '1박 2일'의 복불복 게임에서 벌칙에 걸리지 않은 멤버들이 외치던 말에서 유래했습니다. 초창기 멤버 노홍철이 처음 사용했으며, 이후 강호동이 과장된 표정과 액션으로 외치며 짤방으로 널리 퍼졌습니다. 무한도전의 '무한이기주의'와 비교되며 승리자의 자축을 넘어 타인의 불행을 조롱하는 의미로 변모했습니다.",
+                "원래는 복불복에서 살아남은 자의 자축이었으나, 시간이 지나며 타인의 불행을 보고 자신은 괜찮다며 조롱하는 용법으로 사용됩니다. 인터넷 커뮤니티에서 고소 사건, 단체 손해, 가해자 특정, 지탄받는 대상의 천벌 등 남의 불행에 연루되지 않은 사람들이 이를 비웃을 때 쓰입니다. 2020년대 이후 '알빠노' 등 극단적 이기주의 밈의 시초격으로 인식됩니다.",
+                "2020",
+                "\"[\"\"1박2일\"\", \"\"복불복\"\", \"\"노홍철\"\", \"\"강호동\"\", \"\"이기주의\"\", \"\"남의불행\"\", \"\"짤방\"\", \"\"인터넷밈\"\", \"\"알빠노\"\"]\""
+            );
+    }
+
+    @Test
+    void 존재하지_않는_밈을_조회하면_예외를_발생한다() {
+        Meme 나만_아니면_돼 = Meme.builder()
+            .title("나만 아니면 돼")
+            .origin("KBS 2TV '1박 2일'의 복불복 게임에서 벌칙에 걸리지 않은 멤버들이 외치던 말에서 유래했습니다. 초창기 멤버 노홍철이 처음 사용했으며, 이후 강호동이 과장된 표정과 액션으로 외치며 짤방으로 널리 퍼졌습니다. 무한도전의 '무한이기주의'와 비교되며 승리자의 자축을 넘어 타인의 불행을 조롱하는 의미로 변모했습니다.")
+            .usageContext("원래는 복불복에서 살아남은 자의 자축이었으나, 시간이 지나며 타인의 불행을 보고 자신은 괜찮다며 조롱하는 용법으로 사용됩니다. 인터넷 커뮤니티에서 고소 사건, 단체 손해, 가해자 특정, 지탄받는 대상의 천벌 등 남의 불행에 연루되지 않은 사람들이 이를 비웃을 때 쓰입니다. 2020년대 이후 '알빠노' 등 극단적 이기주의 밈의 시초격으로 인식됩니다.")
+            .trendPeriod("2020")
+            .hashtags("\"[\"\"1박2일\"\", \"\"복불복\"\", \"\"노홍철\"\", \"\"강호동\"\", \"\"이기주의\"\", \"\"남의불행\"\", \"\"짤방\"\", \"\"인터넷밈\"\", \"\"알빠노\"\"]\"")
+            .build();
+        Meme 원영적_사고 = Meme.builder()
+            .title("원영적 사고")
+            .origin("장원영의 평소 초긍정적 사고방식이 팬들 사이에서 알려져 있었으나, 2024년 3월 15일 팬 계정의 프메 패러디 트윗이 SNS에 퍼지며 대중화되었습니다. 이후 기업 세미나에 등장하며 확산되었고, 그녀의 긍정적 태도가 악플 속에서도 빛나며 큰 공감을 얻었습니다. '럭키비키'는 핵심 문구입니다.")
+            .usageContext("자신에게 일어나는 모든 일이 결국 긍정적인 결과로 이어질 것이라는 초월적인 낙관주의를 표현할 때 사용됩니다. 부정적인 상황을 단순히 외면하는 것이 아니라, 현재의 어려움도 결국 자신을 성장시키는 과정으로 받아들이며 긍정적으로 치환하는 사고방식입니다. \"\"완전 럭키비키잖아~\"\"와 함께 쓰입니다.")
+            .trendPeriod("2024")
+            .hashtags("\"[\"\"장원영\"\", \"\"원영적사고\"\", \"\"럭키비키\"\", \"\"초긍정\"\", \"\"긍정적사고\"\", \"\"인터넷밈\"\", \"\"아이브\"\"]\"")
+            .build();
+        Meme 무야호 = Meme.builder()
+            .title("무야호")
+            .origin("2010년 MBC 예능 프로그램 '무한도전' 알래스카 특집에서 유재석, 정형돈, 노홍철이 현지 교민 최규재 할아버지에게 '무한~도전!' 구호를 요청하자, 할아버지가 당황하며 '무야~ 호~!'라고 외친 장면에서 유래했습니다. 방영 당시에는 큰 주목을 받지 못했으나, 2018년 이후 유튜브 알고리즘과 팬 페이지를 통해 재발견되며 폭발적인 인기를 얻었습니다.")
+            .usageContext("예상치 못한 상황에서 터져 나오는 순수한 기쁨, 환희, 또는 놀라움을 표현할 때 사용됩니다. 때로는 상황이 다소 어이없거나 엉뚱할 때의 유쾌함을 나타내기도 합니다. 특정 인물이나 상황에 대한 비난 또는 칭찬의 맥락에서도 사용될 수 있으며, 전반적으로 긍정적이고 유쾌한 분위기를 조성하는 데 활용됩니다.")
+            .trendPeriod("2018")
+            .hashtags("\"[\"\"무한도전\"\", \"\"무야호\"\", \"\"최규재\"\", \"\"알래스카\"\", \"\"인터넷밈\"\", \"\"유행어\"\", \"\"환희\"\", \"\"기쁨\"\", \"\"감탄사\"\"]\"")
+            .build();
+
+        memeRepository.saveAll(List.of(나만_아니면_돼, 원영적_사고, 무야호));
+
+        // when & then
+        thenThrownBy(() -> memeLookUpService.getMemeById(999L))
+            .isInstanceOf(MemeWikiApplicationException.class)
+            .extracting(exception -> ((MemeWikiApplicationException) exception).getErrorType())
+            .isEqualTo(ErrorType.MEME_NOT_FOUND);
     }
 }


### PR DESCRIPTION
# 구현내용
- 밈 검색
- 밈 상세조회
- 밈 상세조회 시 비동기로 조회로그 증적

# 공유사항
- 현재 밈 제목만 검색합니다. 쿼리는 like '%검색어%' 라서 인덱스 안탑니다 :sad
- 근데 우리 상세화면을 확인 못해서 그런데 일단 상세랑 목록조회랑 같은 응답이 필요한거같아서 일단 이렇게 했는데 바뀌거나 하면 수정하면 될듯합니다