### PR TITLE
인기밈을 캐싱한다

### DIFF
--- a/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
+++ b/src/main/java/spring/memewikibe/api/controller/meme/MemeController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import spring.memewikibe.api.controller.meme.response.CategoryResponse;
 import spring.memewikibe.api.controller.meme.response.MemeDetailResponse;
 import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+import spring.memewikibe.application.MemeAggregationLookUpCacheProxyService;
 import spring.memewikibe.application.MemeAggregationLookUpService;
 import spring.memewikibe.application.MemeAggregationService;
 import spring.memewikibe.application.MemeLookUpService;
@@ -22,7 +23,7 @@ public class MemeController {
     private final MemeLookUpService memeLookUpService;
     private final MemeAggregationLookUpService memeAggregationLookUpService;
 
-    public MemeController(MemeAggregationService aggregationService, MemeLookUpService memeLookUpService, MemeAggregationLookUpService memeAggregationLookUpService) {
+    public MemeController(MemeAggregationService aggregationService, MemeLookUpService memeLookUpService, MemeAggregationLookUpCacheProxyService memeAggregationLookUpService) {
         this.aggregationService = aggregationService;
         this.memeLookUpService = memeLookUpService;
         this.memeAggregationLookUpService = memeAggregationLookUpService;

--- a/src/main/java/spring/memewikibe/application/MemeAggregationLookUpCacheProxyService.java
+++ b/src/main/java/spring/memewikibe/application/MemeAggregationLookUpCacheProxyService.java
@@ -1,0 +1,52 @@
+package spring.memewikibe.application;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class MemeAggregationLookUpCacheProxyService implements MemeAggregationLookUpService {
+
+    private final MemeAggregationLookUpService memeAggregationLookUpService;
+
+    private volatile List<MemeSimpleResponse> mostPopularMemesCache;
+
+    public MemeAggregationLookUpCacheProxyService(MemeAggregationLookUpServiceImpl memeAggregationLookUpService) {
+        this.memeAggregationLookUpService = memeAggregationLookUpService;
+    }
+
+    @Override
+    public List<MemeSimpleResponse> getMostFrequentSharedMemes() {
+        return memeAggregationLookUpService.getMostFrequentSharedMemes();
+    }
+
+    @Override
+    public List<MemeSimpleResponse> getMostFrequentCustomMemes() {
+        return memeAggregationLookUpService.getMostFrequentCustomMemes();
+    }
+
+    @Override
+    public List<MemeSimpleResponse> getMostPopularMemes() {
+        if (mostPopularMemesCache == null) {
+            mostPopularMemesCache = memeAggregationLookUpService.getMostPopularMemes();
+        }
+        return mostPopularMemesCache;
+    }
+
+    @PostConstruct
+    public void warmUpCache() {
+        mostPopularMemesCache = memeAggregationLookUpService.getMostPopularMemes();
+    }
+
+    @Scheduled(cron = "0 */30 * * * *")
+    public void refreshCache() {
+        log.info("Refreshing most popular memes cache");
+        mostPopularMemesCache = memeAggregationLookUpService.getMostPopularMemes();
+        log.info("Cache refreshed successfully");
+    }
+}

--- a/src/main/java/spring/memewikibe/config/ScheduleConfig.java
+++ b/src/main/java/spring/memewikibe/config/ScheduleConfig.java
@@ -1,0 +1,9 @@
+package spring.memewikibe.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfig {
+}

--- a/src/test/java/spring/memewikibe/application/MemeAggregationLookUpCacheProxyServiceTest.java
+++ b/src/test/java/spring/memewikibe/application/MemeAggregationLookUpCacheProxyServiceTest.java
@@ -1,0 +1,108 @@
+package spring.memewikibe.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import spring.memewikibe.api.controller.meme.response.MemeSimpleResponse;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemeAggregationLookUpCacheProxyServiceTest {
+
+    @Mock
+    private MemeAggregationLookUpServiceImpl mockOriginService;
+
+    @InjectMocks
+    private MemeAggregationLookUpCacheProxyService cacheProxyService;
+
+    private List<MemeSimpleResponse> testMemes;
+
+    @BeforeEach
+    void setUp() {
+        testMemes = Arrays.asList(
+            new MemeSimpleResponse(1L, "무야호", "무야호.jpg"),
+            new MemeSimpleResponse(2L, "나만 아니면 돼", "나만아니면돼.jpg"),
+            new MemeSimpleResponse(3L, "전남친 토스트", "전남친토스트.jpg")
+        );
+    }
+
+    @Test
+    void getMostPopularMemes는_캐시가_null이면_원본_서비스를_호출하고_결과를_캐시한다() {
+        // given
+        when(mockOriginService.getMostPopularMemes()).thenReturn(testMemes);
+
+        // when
+        List<MemeSimpleResponse> result = cacheProxyService.getMostPopularMemes();
+
+        // then
+        then(result).isEqualTo(testMemes);
+        verify(mockOriginService, times(1)).getMostPopularMemes();
+    }
+
+    @Test
+    void getMostPopularMemes_캐시가_있으면_원본_서비스를_호출하지_않고_캐시를_반환한다() {
+        // given
+        when(mockOriginService.getMostPopularMemes()).thenReturn(testMemes);
+        cacheProxyService.warmUpCache();
+        reset(mockOriginService);
+
+        // when
+        List<MemeSimpleResponse> result = cacheProxyService.getMostPopularMemes();
+
+        // then
+        then(result).isEqualTo(testMemes);
+        verify(mockOriginService, never()).getMostPopularMemes();
+    }
+
+    @Test
+    void getMostPopularMemes_여러_번_호출해도_첫_번째만_원본_서비스를_호출한다() {
+        // given
+        when(mockOriginService.getMostPopularMemes()).thenReturn(testMemes);
+
+        // when
+        cacheProxyService.getMostPopularMemes();
+        cacheProxyService.getMostPopularMemes();
+        cacheProxyService.getMostPopularMemes();
+
+        // then
+        verify(mockOriginService, times(1)).getMostPopularMemes();
+    }
+
+    @Test
+    void getMostFrequentSharedMemes는_항상_원본_서비스를_호출한다() {
+        // given
+        when(mockOriginService.getMostFrequentSharedMemes()).thenReturn(testMemes);
+
+        // when
+        List<MemeSimpleResponse> result1 = cacheProxyService.getMostFrequentSharedMemes();
+        List<MemeSimpleResponse> result2 = cacheProxyService.getMostFrequentSharedMemes();
+
+        // then
+        then(result1).isEqualTo(testMemes);
+        then(result2).isEqualTo(testMemes);
+        verify(mockOriginService, times(2)).getMostFrequentSharedMemes(); // 매번 호출
+    }
+
+    @Test
+    void getMostFrequentCustomMemes는_항상_원본_서비스를_호출한다() {
+        // given
+        when(mockOriginService.getMostFrequentCustomMemes()).thenReturn(testMemes);
+
+        // when
+        List<MemeSimpleResponse> result1 = cacheProxyService.getMostFrequentCustomMemes();
+        List<MemeSimpleResponse> result2 = cacheProxyService.getMostFrequentCustomMemes();
+
+        // then
+        then(result1).isEqualTo(testMemes);
+        then(result2).isEqualTo(testMemes);
+        verify(mockOriginService, times(2)).getMostFrequentCustomMemes(); // 매번 호출
+    }
+}


### PR DESCRIPTION
# 구현내용
- 인기밈 캐싱
- volatile 통해서 동시성문제에서 가시성 확보

# 공유사항
- 캐시 외부 의존성 안쓰고 List 쓰고 volatile로 동시성에서 가시성만 확보 이렇게 한 근거는 ttl도 필요없고, 캐시를 갱신하거나 비울 일이 없어서 그냥 간단하게 프록시서비스 만들어서 List로 관리하도록 하였습니다.
- 테스트는 프록시서비스니까 원본 서비스 부르는지만 확인하는 verfiy위주의 mocking test입니다