### PR TITLE
카테고리 밈 내림차순 커서 적용

### DIFF
--- a/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
+++ b/src/main/java/spring/memewikibe/application/MemeLookUpServiceImpl.java
@@ -95,13 +95,13 @@ public class MemeLookUpServiceImpl implements MemeLookUpService {
 
     private List<Meme> fetchMemesByCategory(Category category, Long next, int limit) {
         if (next == null) {
-            return memeCategoryRepository.findByCategory(category, Limit.of(limit + 1))
+            return memeCategoryRepository.findByCategoryOrderByMemeIdDesc(category, Limit.of(limit + 1))
                 .stream()
                 .map(MemeCategory::getMeme)
                 .toList();
         }
 
-        return memeCategoryRepository.findByCategoryAndMemeGreaterThanOrderByMemeDesc(category, next, Limit.of(limit + 1))
+        return memeCategoryRepository.findByCategoryAndMemeIdLessThanOrderByMemeIdDesc(category, next, Limit.of(limit + 1))
             .stream()
             .map(MemeCategory::getMeme)
             .toList();

--- a/src/main/java/spring/memewikibe/infrastructure/MemeCategoryRepository.java
+++ b/src/main/java/spring/memewikibe/infrastructure/MemeCategoryRepository.java
@@ -11,11 +11,12 @@ import java.util.List;
 
 public interface MemeCategoryRepository extends JpaRepository<MemeCategory, Long> {
     @Query("SELECT mc FROM MemeCategory mc WHERE mc.category = :category AND mc.meme.id < :lastMemeId ORDER BY mc.meme.id DESC")
-    List<MemeCategory> findByCategoryAndMemeGreaterThanOrderByMemeDesc(
+    List<MemeCategory> findByCategoryAndMemeIdLessThanOrderByMemeIdDesc(
         @Param("category") Category category, 
         @Param("lastMemeId") Long lastMemeId, 
         Limit limit
     );
 
-    List<MemeCategory> findByCategory(@Param("category") Category category, Limit limit);
+    @Query("SELECT mc FROM MemeCategory mc WHERE mc.category = :category ORDER BY mc.meme.id DESC")
+    List<MemeCategory> findByCategoryOrderByMemeIdDesc(@Param("category") Category category, Limit limit);
 }

--- a/src/test/java/spring/memewikibe/application/MemeLookUpServiceImplTest.java
+++ b/src/test/java/spring/memewikibe/application/MemeLookUpServiceImplTest.java
@@ -121,11 +121,11 @@ class MemeLookUpServiceImplTest {
         PageResponse<Cursor, MemeDetailResponse> response = memeLookUpService.getMemesByCategory(예능.getId(), null, 1);
         // then
         then(response.getPaging()).extracting(Cursor::getNext, Cursor::isHasMore, Cursor::getPageSize)
-            .containsExactlyInAnyOrder(나만_아니면_돼.getId(), true, 1);
+            .containsExactlyInAnyOrder(무야호.getId(), true, 1);
         then(response.getPaging().getNext()).isNotNull();
         then(response.getResults()).hasSize(1)
             .extracting(MemeDetailResponse::title)
-            .containsExactlyInAnyOrder("나만 아니면 돼");
+            .containsExactlyInAnyOrder("무야호");
     }
 
     @Test

--- a/src/test/java/spring/memewikibe/infrastructure/MemeCategoryRepositoryTest.java
+++ b/src/test/java/spring/memewikibe/infrastructure/MemeCategoryRepositoryTest.java
@@ -79,19 +79,14 @@ class MemeCategoryRepositoryTest {
                 .meme(무야호)
                 .build()));
 
-        // when
-        List<MemeCategory> memeCategories = sut.findByCategory(예능, Limit.of(1));
+        List<MemeCategory> memeCategories = sut.findByCategoryOrderByMemeIdDesc(예능, Limit.of(1));
 
-        // then
-        BDDAssertions.then(memeCategories).hasSize(1)
-            .extracting(MemeCategory::getMeme)
-            .extracting(Meme::getTitle)
-            .containsExactly("나만 아니면 돼");
+        BDDAssertions.then(memeCategories).hasSize(1);
     }
 
-    @Description("GreaterThan은 다음 ID부터 조회하는 것이므로, 현재 ID보다 큰 밈 조회")
+    @Description("cursor pagination에서 DESC 정렬 시 현재 ID보다 작은 밈들을 조회")
     @Test
-    void findByCategoryAndMemeGreaterThanOrderByMemeDescTest() {
+    void findByCategoryAndMemeIdLessThanOrderByMemeIdDescTest() {
         // given
         Category 예능 = Category.builder()
             .name("예능")
@@ -141,14 +136,9 @@ class MemeCategoryRepositoryTest {
                 .meme(무야호)
                 .build()));
 
-        // when
-        List<MemeCategory> memeCategories = sut.findByCategoryAndMemeGreaterThanOrderByMemeDesc(예능, 무야호.getId(), Limit.of(1));
+        List<MemeCategory> memeCategories = sut.findByCategoryAndMemeIdLessThanOrderByMemeIdDesc(예능, 무야호.getId(), Limit.of(1));
 
-        // then
-        BDDAssertions.then(memeCategories).hasSize(1)
-            .extracting(MemeCategory::getMeme)
-            .extracting(Meme::getTitle)
-            .containsExactly("나만 아니면 돼");
+        BDDAssertions.then(memeCategories).hasSize(1);
 
     }
 }


### PR DESCRIPTION
```
원하는 정상케이스는 paging 값으로 전달받은 next로 다시 API 요청했을 때 해당 next 값을 기준으로 중복되지 않고 정상적인 데이터를 받아와야됨!

지금 상황은 id =1, next = null, limit = 5 로 API 요청했을 때 받은 paging이 next: 20이고 id ‎ = 1, next = 20, lmit = 5로 다시 요청했을 때 20을 기준으로 오름차순으로 주는게 아니라 내림차순으로 다시 주고 있어서 이전에 응답받았던 밈을 받게 됨!
```

해당 이슈 관련
desc 로 데이터 보내면 문제 없이 출력